### PR TITLE
Add ruby haml grammar

### DIFF
--- a/lib/grammar-mapping.coffee
+++ b/lib/grammar-mapping.coffee
@@ -17,6 +17,7 @@ module.exports =
   "Regular Expressions (Python)": null
   "HTML (Ruby - ERB)": "HTML"
   "HTML (Rails)": "HTML"
+  "Ruby Haml": "HAML"
   "Ruby on Rails (RJS)": "Ruby"
   "Ruby on Rails": "Ruby"
   "JavaScript (Rails)": "JavaScript"


### PR DESCRIPTION
Without the grammar, you cannot use the copy-as-rtf package and the package silently fails to copy the selection to the clipboard. Adding the "Ruby Haml" grammar to syntax highlight as HAML, which seems to work even thought it's not listed on http://pygments.org/languages/. 