### PR TITLE
Add fontsize option.

### DIFF
--- a/lib/copy-as-rtf.coffee
+++ b/lib/copy-as-rtf.coffee
@@ -6,11 +6,13 @@ mapping = require './grammar-mapping'
 module.exports =
   configDefaults:
     fontface: 'Monaco',
+    fontsize: 16,
     style: 'tango'
 
   activate: ->
     atom.config.setDefaults 'copy-as-rtf',
       fontface: @configDefaults.fontface,
+      fontsize: @configDefaults.fontsize,
       style: @configDefaults.style
 
     atom.commands.add 'atom-workspace', "copy-as-rtf:copy", => @copy()
@@ -29,6 +31,7 @@ module.exports =
       format: 'rtf',
       options:
         fontface: atom.config.get('copy-as-rtf.fontface'),
+        fontsize: atom.config.get('copy-as-rtf.fontsize') * 2,
         style: atom.config.get('copy-as-rtf.style'),
 
     pygmentize opts, source, (err, result) ->


### PR DESCRIPTION
Specifying font size is really useful when copying into other apps, e.g. Keynote.

`fontsize` uses half-points and therefore is multiplied by `2`.
http://pygments.org/docs/formatters/#RtfFormatter